### PR TITLE
feat: better translation for type a and ba coordinates

### DIFF
--- a/tests/test_translation.py
+++ b/tests/test_translation.py
@@ -106,7 +106,7 @@ def test_harmonics_translation_coef[TSpherical, TCartesian](
     xp: ArrayNamespaceFull,
     method: Literal["gumerov", "plane_wave", "triplet"],
 ) -> None:
-    if method == "gumerov" and c.branching_types_expression_str != "ba":
+    if method == "gumerov" and c.branching_types_expression_str not in ["a", "ba"]:
         pytest.skip("gumerov method only supports ba branching type")
     if method == "plane_wave" and from_ != to_:
         pytest.skip("plane_wave method only supports from_=to_")


### PR DESCRIPTION
<!--
  😀 Wonderful!  Thank you for opening a pull request.

  By submitting this pull request, you agree to follow our [Code of Conduct](https://github.com/ultrasphere-dev/ultrasphere-harmonics/blob/main/.github/CODE_OF_CONDUCT.md).

  Please fill in the information below to expedite the review
  and (hopefully) merge of your change.
-->

### Description of change

<!--
  Please be clear and concise what the change is intended to do,
  why this change is needed, and how you've verified that it
  corrects what you intended.

  In some cases it may be helpful to include the current behavior
  and the new behavior.

  If the change is related to an open issue, you can link it here.
  If you include `Fixes #0000` (replacing `0000` with the issue number)
  when this is merged it will automatically mark the issue as fixed and
  close it.
-->

### Pull-Request Checklist

<!--
  Please make sure to review and check all of the following to merge this PR.

  Note that there is no problem if they are not checked when this PR is created.

  If an item is not applicable, you can add "N/A" to the end.
-->

- [ ] Code is up-to-date with the `main` branch
- [ ] This pull request follows the [contributing guidelines](https://github.com/ultrasphere-dev/ultrasphere-harmonics/blob/main/CONTRIBUTING.md).
- [ ] This pull request links relevant issues as `Fixes #0000`
- [ ] There are new or updated unit tests validating the change
- [ ] Documentation has been updated to reflect this change
- [ ] The new commits follow conventions outlined in the [conventional commit spec](https://www.conventionalcommits.org/en/v1.0.0/), such as "fix(api): prevent racing of requests".

> - If pre-commit.ci is failing, try `pre-commit run -a` for further information.
> - If CI / test is failing, try `uv run pytest` for further information.

<!--
  🎉 Thank you for contributing!
-->
